### PR TITLE
`cd` and `nano` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ﻿# GrapeFruit OS - Powered by Cosmos
 ## Changelog
 
+### 2023-04-02
+- Fixed an issue where if you used `touch` to create a file, then opened it with `nano`,
+  `nano` would crash because the file was literally 0 in length.
+  `touch` now adds a zero character (`\0`) to every file created, so `nano` won't crash
+
 ### 2023-04-01
 - Reorganised `help` command
 - Introduced `nano`

--- a/FS.cs
+++ b/FS.cs
@@ -64,7 +64,14 @@ namespace GrapeFruit_CosmosRolling
                 try
                 {
                     if (!File.Exists(filename))
+                    {
                         File.Create(filename);
+
+                        //Adding a zero character to the file, so nano doesn't crash when opening it
+                        StreamWriter writer = new StreamWriter(filename);
+                        writer.Write('\0');
+                        writer.Close();
+                    }
                     else
                         Console.WriteLine("File already exists");
                 }

--- a/GrapeFruit_CosmosRolling.csproj
+++ b/GrapeFruit_CosmosRolling.csproj
@@ -6,6 +6,7 @@
         <Platform>cosmos</Platform>
         <SupportsX86Intrinsics>false</SupportsX86Intrinsics>
         <SelfContained>True</SelfContained>
+        <Configurations>Debug;Release;ISO</Configurations>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/GrapeFruit_CosmosRolling.sln
+++ b/GrapeFruit_CosmosRolling.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GrapeFruit_CosmosRolling", "GrapeFruit_CosmosRolling.csproj", "{5A070B3F-396C-4CCA-A1E8-EB4AC60C5358}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrapeFruit_CosmosRolling", "GrapeFruit_CosmosRolling.csproj", "{5A070B3F-396C-4CCA-A1E8-EB4AC60C5358}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This version of GrapeFruitOS implements `cd` functionality into the shell.

Biggest addition of this update is `nano` which is highly similar to GNU Nano on *nix systems

See changelog, `help` and `whatis` for more info