### PR TITLE
Merge 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ﻿# GrapeFruit OS - Powered by Cosmos
 ## Changelog
 
+### 2026-01-02 | 0.16.1
+- Cleaned up the "mandb" a little
+    - every switch now sets 2 variables, instead of individual console writelines
+    - Help text formatting now follows Unix man page standards
+- Minor change in `la`, columns now have headers to describe which is which
+
 ### 2025-09-15 | 0.16
 - Minor fixes with TUI, displayed text
 - Updated a few help tips

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 ﻿# GrapeFruit OS - Powered by Cosmos
 ## Changelog
 
+### 2025-09-15
+- Added `env` to list environment variables and `envedit` to edit them
+- Added safe delete variable to system, asks Y/N before `rm` is run, can be toggled
+- `rm` can now take `-d` and `-r` parameters, see `whatis`
+- Reworked error screen
+- System can be toggled to compile for UEFI boot instead of legacy
+- Implemented functionality in regards to *"old pwd"*
+    - `cd $OLDPWD` or `cd -` takes you back to the previous PWD
+    - `oldpwd` env var gets updated on each `cd`
+- Worked on minor issues in regards to `ls` and `la`
+- Bumped version number to 0.15
+
 ### 2024-10-28
 - `nano` rework
 - Removed many `Logger.Debug` entries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ﻿# GrapeFruit OS - Powered by Cosmos
 ## Changelog
 
+### 2025-09-15 | 0.16
+- Minor fixes with TUI, displayed text
+- Updated a few help tips
+- Fixed a bug with `cd` which made it impossible to use relative paths
+- Changed a few `Console.Clear()` entries to `Console.WriteLine()` in `envedit` to see the entire workflow
+- Added `whatis` entries for `env` and `envedit`
+- Bumped vernum to 0.16
+
 ### 2025-09-15
 - Added `env` to list environment variables and `envedit` to edit them
 - Added safe delete variable to system, asks Y/N before `rm` is run, can be toggled

--- a/Command.cs
+++ b/Command.cs
@@ -1,8 +1,6 @@
 ﻿using Cosmos.System.FileSystem;
 using Cosmos.System.Network.Config;
-using grapeFruitRebuild.Filesystem;
 using System;
-//using grapeFruitOSCSharp.Filesystem;
 using System.Collections.Generic;
 
 namespace grapeFruitRebuild
@@ -90,6 +88,14 @@ namespace grapeFruitRebuild
                         Commands();
                     break;
 
+                case "env":
+                    Globals.env();
+                    break;
+
+                case "envedit":
+                    Globals.envEdit();
+                    break;
+
                 case "throwex":
                     throw new Exception("Manually triggered exception");
 
@@ -106,14 +112,14 @@ namespace grapeFruitRebuild
                     if (splitinput.Count > 1)
                         FS.List(splitinput[1]);
                     else
-                        FS.List();
+                        FS.List("");
                     break;
 
                 case "la":
                     if (splitinput.Count > 1)
                         FS.VerboseList(splitinput[1]);
                     else
-                        FS.VerboseList();
+                        FS.VerboseList("");
                     break;
 
                 case "cd":
@@ -182,7 +188,21 @@ namespace grapeFruitRebuild
 
                 case "rm":
                     if (splitinput.Count > 1)
-                        FS.Remove(splitinput[1]);
+                    {
+                        if (Globals.safeDelete)
+                        {
+                            if (Choice())
+                            {
+                                Console.Write('\n');
+                                FS.Remove(splitinput);
+                            }
+                            else
+                                return;
+
+                        }
+                        else
+                            FS.Remove(splitinput);
+                    }
                     else
                         Console.WriteLine("Not enough parameters");
                     break;
@@ -247,7 +267,8 @@ namespace grapeFruitRebuild
 
                 case "debug":
                     Console.WriteLine("throwex - throws test exception");
-                    //Console.WriteLine("keytest - test keyboard keycodes");
+                    Console.WriteLine("env - Lists environment variables");
+                    Console.WriteLine("envedit  - Environment variable editor");
                     break;
             }
         }

--- a/Command.cs
+++ b/Command.cs
@@ -291,20 +291,14 @@ namespace grapeFruitRebuild
 
         static void Shutdown()
         {
-            //choice
-            if (Choice())
-            {
+            if(Choice())
                 Cosmos.System.Power.Shutdown();
-            }
         }
 
         static void Reboot()
         {
-            //choice
-            if (Choice())
-            {
+            if(Choice())
                 Cosmos.System.Power.Reboot();
-            }
         }
 
         static bool Choice()

--- a/Command.cs
+++ b/Command.cs
@@ -22,7 +22,6 @@ namespace grapeFruitRebuild
             else if (splitpwd.Length > 2)
                 Console.Write($"{splitpwd[splitpwd.Length - 2]}]> ");
 
-
             Console.ForegroundColor = ConsoleColor.White;
             string command = Console.ReadLine();
             ParseInput(command);
@@ -233,7 +232,7 @@ namespace grapeFruitRebuild
 
                 case "system":
                     Console.WriteLine("Available commands in \"system\" category:\n");
-                    Console.WriteLine("help/commands - shows command list");
+                    Console.WriteLine("help/commands <category> - shows command list in category");
                     Console.WriteLine("echo <message> - prints to screen");
                     Console.WriteLine("clear - clears screen");
                     Console.WriteLine("time - shows current time (RTC)");
@@ -255,9 +254,9 @@ namespace grapeFruitRebuild
                     Console.WriteLine("Available commands in \"fs\" category:\n");
                     Console.WriteLine("ls/dir - list directory contents");
                     Console.WriteLine("la - verbose listing of directory contents");
-                    Console.WriteLine("rm - remove file");
+                    Console.WriteLine("rm - remove file or directory (-d) recursively (-r)");
                     Console.WriteLine("touch <filename> - create empty file with specified name");
-                    Console.WriteLine("cat <filename> - print file contents");
+                    Console.WriteLine("cat <filename> - read file contents to screen");
                     Console.WriteLine("mkdir/md <name> - creates directory with name");
                     Console.WriteLine("copy/cp <source> <target> - copies file from source to target (if source exists)");
                     Console.WriteLine("move/mv <source> <target> - moves file from source to target (if source exists)");

--- a/ErrorScreen.cs
+++ b/ErrorScreen.cs
@@ -14,14 +14,14 @@ namespace grapeFruitRebuild
 
         public static void SpecifiedError(Exception e)
         {
-            Logger.Log(4, "Critical failure");
-            Console.WriteLine("A critical error occured");
-            Console.WriteLine("\nException message: " + e.Message);
-            Console.WriteLine("Exception ToString: " + e.ToString());
-            Console.WriteLine("\nSystem integrity might be compromised. Press a key to continue");
+            Console.WriteLine();
+            Logger.Log(4, "Critical Stop");
+            Console.WriteLine("A critical stop was triggered during execution!");
+            Console.WriteLine(e.ToString());
 
-            Logger.Debug("Exception message: " + e.Message + "\nException ToString: " + e.ToString());
+            Logger.Debug("Critical stop: " + e.ToString());
 
+            Console.WriteLine("\nSystem integrity might be compromised.\nPress a key to continue");
             Console.ReadKey();
         }
 

--- a/FS.cs
+++ b/FS.cs
@@ -260,13 +260,25 @@ namespace grapeFruitRebuild
                                 Console.WriteLine("FS.Chdir: Directory does not exist!");
                             break;
                         default:
+                            path = path.Contains(@":\") ? path : Globals.workingdir + path + '\\';
+
                             if (Directory.Exists(path))
                             {
                                 Globals.oldpwd = Globals.workingdir;
-                                Globals.workingdir = path.Contains(@":\") ? path : path + '\\';
+                                Globals.workingdir = path;
                             }
                             else
-                                Console.WriteLine("FS.Chdir: Directory does not exist!");
+                            {
+                                //Ensuring the user cannot go to invalid path
+                                Globals.oldpwd = Globals.workingdir;
+
+                                //Telling user about wrong path
+                                Console.Write("Directory ");
+                                Console.ForegroundColor = ConsoleColor.Yellow;
+                                Console.Write("\"" + path + "\"");
+                                Console.ForegroundColor = ConsoleColor.White;
+                                Console.WriteLine(" not found!");
+                            }
                             break;
                     }
                 }

--- a/FS.cs
+++ b/FS.cs
@@ -92,6 +92,7 @@ namespace grapeFruitRebuild
                 {
                     //string[] filePaths = Directory.GetFiles(path);
                     Console.WriteLine("\nVerbose listing of " + path);
+                    Console.WriteLine("\ntype\t\tname\tsize");
                     Console.ForegroundColor = ConsoleColor.Yellow;   
                     foreach (var d in Directory.GetDirectories(path))
                     {

--- a/FS.cs
+++ b/FS.cs
@@ -317,7 +317,10 @@ namespace grapeFruitRebuild
                     if (Directory.Exists(path) && Directory.GetDirectories(path) == Array.Empty<string>() && Directory.GetFiles(path) == Array.Empty<string>())
                         Directory.Delete(path, false);
                     else
+                    {
                         Console.WriteLine("FS.Remove: Directory not empty");
+                        return;
+                    }
 
                 }
                 if (args[1] == "-r")

--- a/FS.cs
+++ b/FS.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using Cosmos.HAL.BlockDevice;
 
-namespace grapeFruitRebuild.Filesystem
+namespace grapeFruitRebuild
 {
     public class FS
     {
@@ -44,7 +44,7 @@ namespace grapeFruitRebuild.Filesystem
                 if (Directory.Exists(path))
                 {
                     string[] filePaths = Directory.GetFiles(path);
-                    Console.WriteLine("\nDirectory listing of {0}", path);
+                    Console.WriteLine("\nDirectory listing of " + path);
                     Console.ForegroundColor = ConsoleColor.Yellow;
                     foreach (var d in Directory.GetDirectories(path))
                     {
@@ -69,7 +69,7 @@ namespace grapeFruitRebuild.Filesystem
                 {
                     Console.Write("Directory ");
                     Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.Write("\"{0}\"", path);
+                    Console.Write("\"" + path + "\"");
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.WriteLine(" not found!");
                 }
@@ -79,7 +79,6 @@ namespace grapeFruitRebuild.Filesystem
 
         public static void VerboseList(string path = "")
         {
-
             if(Globals.vFS != null) 
             {
                 if(path == "")
@@ -91,9 +90,9 @@ namespace grapeFruitRebuild.Filesystem
 
                 if (Directory.Exists(path))
                 {
-                    string[] filePaths = Directory.GetFiles(path);
-                    Console.WriteLine("\nVerbose listing of {0}", path);
-                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    //string[] filePaths = Directory.GetFiles(path);
+                    Console.WriteLine("\nVerbose listing of " + path);
+                    Console.ForegroundColor = ConsoleColor.Yellow;   
                     foreach (var d in Directory.GetDirectories(path))
                     {
                         var dir = new DirectoryInfo(d);
@@ -108,6 +107,7 @@ namespace grapeFruitRebuild.Filesystem
 
                         Console.Write("\n");
                     }
+                    
 
                     Console.ForegroundColor = ConsoleColor.Blue;
 
@@ -129,13 +129,13 @@ namespace grapeFruitRebuild.Filesystem
                         Console.Write("\n");
                     }
                     Console.ForegroundColor = ConsoleColor.White;
-                    Console.WriteLine("\nTotal: " + $"{Globals.drive.TotalSize}" + " b / Free: " + $"{Globals.drive.AvailableFreeSpace}" + " b\n");
+                    Console.WriteLine("\nTotal: " + Globals.drive.TotalSize + " b / Free: " + Globals.drive.AvailableFreeSpace + " b\n");
                 }
                 else
                 {
                     Console.Write("Directory ");
                     Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.Write("\"{0}\"", path);
+                    Console.Write("\"" + path + "\"");
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.WriteLine(" not found!");
                 }
@@ -227,36 +227,58 @@ namespace grapeFruitRebuild.Filesystem
                 Logger.Log(2, "FS.Chdir: Virtual Filesystem is not initialised!");
             else
             {
-                if (path == "..")
+                try
                 {
-                    string[] splitpath = Globals.workingdir.Split(@"\");
+                    switch (path)
+                    {
+                        case "..":
+                            string[] splitpath = Globals.workingdir.Split(@"\");
 
-                    //We can't do this:
-                    //splitpath = splitpath.SkipLast(1).ToArray();
-                    //so instead we'll convert it by hand
-                    List<string> temp = new();
-                    for (int i = 0; i < splitpath.Length - 2; i++)
-                        temp.Add(splitpath[i]);
+                            //We can't do this:
+                            //splitpath = splitpath.SkipLast(1).ToArray();
+                            //so instead we'll convert it by hand
+                            List<string> temp = new();
+                            for (int i = 0; i < splitpath.Length - 2; i++)
+                                temp.Add(splitpath[i]);
 
-                    Globals.workingdir = "";
-                    for (int i = 0; i < temp.Count; i++)
-                        Globals.workingdir += temp[i] + "\\";
+                            Globals.workingdir = "";
+                            for (int i = 0; i < temp.Count; i++)
+                                Globals.workingdir += temp[i] + "\\";
 
-                    //Very "hack-like" solution but it's almost 12am, I'll fix it later
+                            //Very "hack-like" solution but it's almost 12am, I'll fix it later
+                            break;
+
+                        case "$OLDPWD":
+                        case "-":
+                            //Check if we can even go back to that directory
+                            if (Directory.Exists(Globals.oldpwd))
+                            {
+                                //Using a "tuple" to swap values, as suggested by VS
+                                (Globals.oldpwd, Globals.workingdir) = (Globals.workingdir, Globals.oldpwd);
+                            }
+                            else
+                                Console.WriteLine("FS.Chdir: Directory does not exist!");
+                            break;
+                        default:
+                            if (Directory.Exists(path))
+                            {
+                                Globals.oldpwd = Globals.workingdir;
+                                Globals.workingdir = path.Contains(@":\") ? path : path + '\\';
+                            }
+                            else
+                                Console.WriteLine("FS.Chdir: Directory does not exist!");
+                            break;
+                    }
                 }
-                else if (!path.Contains(@":\"))
+                catch (Exception e)
                 {
-                    Globals.workingdir += path + "\\";
-                }
-                else
-                {
-                    Globals.workingdir = path;
+                    ErrorScreen.SpecifiedError(e);
                 }
             }
 
         }
-
-        public static void Remove(string path)
+        //Reworked function to support -d and -r
+        public static void Remove(List<string> args)
         {
             if (Globals.vFS == null)
             {
@@ -264,13 +286,65 @@ namespace grapeFruitRebuild.Filesystem
             }
             else
             {
-                if (!path.Contains(@":\"))
-                    path = Globals.workingdir + path;
+                string path;
+                //First, check if params starts with -d or -r
+                if (args[1] == "-d")
+                {
+                    path = args[2];
+                    if (!path.Contains(@":\"))
+                        path = Globals.workingdir + path;
 
-                if (File.Exists(path))
-                    File.Delete(path);
+                    //Check if path is directory
+                    if (!Directory.Exists(path) && File.Exists(path))
+                    {
+                        Console.WriteLine("FS.Remove: Target is a file");
+                        return;
+                    }
+
+                    //Check if directory is empty
+                    if (Directory.Exists(path) && Directory.GetDirectories(path) == Array.Empty<string>() && Directory.GetFiles(path) == Array.Empty<string>())
+                        Directory.Delete(path, false);
+                    else
+                        Console.WriteLine("FS.Remove: Directory not empty");
+
+                }
+                if (args[1] == "-r")
+                {
+                    path = args[2];
+                    if (!path.Contains(@":\"))
+                        path = Globals.workingdir + path;
+
+                    //Check if path is directory
+                    if (!Directory.Exists(path) && File.Exists(path))
+                    {
+                        Console.WriteLine("FS.Remove: Target is a file");
+                        return;
+                    }
+
+                    if (Directory.Exists(path))
+                        Directory.Delete(path, true);
+                }
                 else
-                    Console.WriteLine("FS.Remove: File does not exist");
+                {
+                    path = args[1];
+
+                    if (!path.Contains(@":\"))
+                        path = Globals.workingdir + path;
+
+                    //Check if path is a file
+                    if (Directory.Exists(path) && !File.Exists(path))
+                    {
+                        Console.WriteLine("FS.Remove: Target is a directory");
+                        return;
+                    }
+                    else
+                    {
+                        if (File.Exists(path))
+                            File.Delete(path);
+                        else
+                            Console.WriteLine("FS.Remove: File does not exist");
+                    }
+                }
             }
         }
 

--- a/Globals.cs
+++ b/Globals.cs
@@ -14,7 +14,7 @@ namespace grapeFruitRebuild
 {
     public class Globals
     {
-        public const string build = "0.12 CosmosRolling-Rebuild";
+        public const string build = "0.15 Alpha";
         public const string osname = "grapeFruitOS";
         public const bool devBuild = true;
 
@@ -33,6 +33,7 @@ namespace grapeFruitRebuild
         public static string oldpwd;
 
         public static bool swapYZ;
+        public static bool safeDelete;
 
         public static void Printsysteminfo()
         {
@@ -55,6 +56,82 @@ namespace grapeFruitRebuild
                 realUsedPercent = usedpercent.ToString();
 
             Console.WriteLine($"Memory usage: {GCImplementation.GetUsedRAM()} / {GCImplementation.GetAvailableRAM() * 1048576} bytes ({realUsedPercent})");
+        }
+
+        public static void env()
+        {
+            Console.WriteLine("devbuild: " + Globals.devBuild);
+            Console.WriteLine("currentuser: " + Globals.currentuser);
+            Console.WriteLine("hostname: " + Globals.hostname);
+            Console.WriteLine("workingdir: " + Globals.workingdir);
+            Console.WriteLine("oldpwd: " + Globals.oldpwd);
+            Console.WriteLine("swapYZ: " + Globals.swapYZ);
+            Console.WriteLine("safeDelete: " + Globals.safeDelete);
+        }
+
+        public static void envEdit()
+        {
+            Console.Clear();
+            Console.WriteLine("Choose variable:\n");
+            Console.WriteLine("1. currentuser\n2. hostname\n3. workingdir\n4. oldpwd\n5. swapYZ\n6. safeDelete");
+            Console.WriteLine("\nUse the number row to choose");
+            Console.Write("> ");
+            string input = "";
+            switch (Console.ReadKey().Key)
+            {
+                case ConsoleKey.D1:
+                    Console.Clear();
+                    Console.WriteLine("Key: currentuser\nType: String\n\nCurrent Value: " + currentuser);
+                    Console.Write("New value: ");
+                    input = Console.ReadLine();
+                    if(input != "")
+                        currentuser = input;
+
+                    Console.WriteLine("currentuser was updated to " + currentuser);
+                    break;
+                case ConsoleKey.D2:
+                    Console.Clear();
+                    Console.WriteLine("Key: hostname\nType: String\n\nCurrent Value: " + hostname);
+                    Console.Write("New value: ");
+                    input = Console.ReadLine();
+                    if (input != "")
+                        hostname = input;
+
+                    Console.WriteLine("hostname was updated to " + hostname);
+                    break;
+                case ConsoleKey.D3:
+                    Console.Clear();
+                    Console.WriteLine("Key: workingdir\nType: String\n\nCurrent Value: " + workingdir);
+                    Console.Write("New value: ");
+                    input = Console.ReadLine();
+                    if (input != "")
+                        workingdir = input;
+
+                    Console.WriteLine("workingdir was updated to " + workingdir);
+                    break;
+                case ConsoleKey.D4:
+                    Console.Clear();
+                    Console.WriteLine("Key: oldpwd\nType: String\n\nCurrent Value: " + oldpwd);
+                    Console.Write("New value: ");
+                    input = Console.ReadLine();
+                    if (input != "")
+                        oldpwd = input;
+
+                    Console.WriteLine("oldpwd was updated to " + oldpwd);
+                    break;
+                case ConsoleKey.D5:
+                    Console.WriteLine("\nswapYZ was " + swapYZ);
+                    swapYZ = !swapYZ;
+                    Console.WriteLine("swapYZ is " + swapYZ);
+                    break;
+                case ConsoleKey.D6:
+                    Console.WriteLine("\nsafeDelete was " + safeDelete);
+                    safeDelete = !safeDelete;
+                    Console.WriteLine("safeDelete is " + safeDelete);
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/Globals.cs
+++ b/Globals.cs
@@ -14,7 +14,7 @@ namespace grapeFruitRebuild
 {
     public class Globals
     {
-        public const string build = "0.15 Alpha";
+        public const string build = "0.16 Alpha";
         public const string osname = "grapeFruitOS";
         public const bool devBuild = true;
 
@@ -71,7 +71,6 @@ namespace grapeFruitRebuild
 
         public static void envEdit()
         {
-            Console.Clear();
             Console.WriteLine("Choose variable:\n");
             Console.WriteLine("1. currentuser\n2. hostname\n3. workingdir\n4. oldpwd\n5. swapYZ\n6. safeDelete");
             Console.WriteLine("\nUse the number row to choose");
@@ -80,7 +79,7 @@ namespace grapeFruitRebuild
             switch (Console.ReadKey().Key)
             {
                 case ConsoleKey.D1:
-                    Console.Clear();
+                    Console.WriteLine();
                     Console.WriteLine("Key: currentuser\nType: String\n\nCurrent Value: " + currentuser);
                     Console.Write("New value: ");
                     input = Console.ReadLine();
@@ -90,7 +89,7 @@ namespace grapeFruitRebuild
                     Console.WriteLine("currentuser was updated to " + currentuser);
                     break;
                 case ConsoleKey.D2:
-                    Console.Clear();
+                    Console.WriteLine();
                     Console.WriteLine("Key: hostname\nType: String\n\nCurrent Value: " + hostname);
                     Console.Write("New value: ");
                     input = Console.ReadLine();
@@ -100,7 +99,7 @@ namespace grapeFruitRebuild
                     Console.WriteLine("hostname was updated to " + hostname);
                     break;
                 case ConsoleKey.D3:
-                    Console.Clear();
+                    Console.WriteLine();
                     Console.WriteLine("Key: workingdir\nType: String\n\nCurrent Value: " + workingdir);
                     Console.Write("New value: ");
                     input = Console.ReadLine();
@@ -110,7 +109,7 @@ namespace grapeFruitRebuild
                     Console.WriteLine("workingdir was updated to " + workingdir);
                     break;
                 case ConsoleKey.D4:
-                    Console.Clear();
+                    Console.WriteLine();
                     Console.WriteLine("Key: oldpwd\nType: String\n\nCurrent Value: " + oldpwd);
                     Console.Write("New value: ");
                     input = Console.ReadLine();

--- a/Globals.cs
+++ b/Globals.cs
@@ -14,7 +14,7 @@ namespace grapeFruitRebuild
 {
     public class Globals
     {
-        public const string build = "0.16 Alpha";
+        public const string build = "0.16.1 Alpha";
         public const string osname = "grapeFruitOS";
         public const bool devBuild = true;
 

--- a/Kernel.cs
+++ b/Kernel.cs
@@ -99,6 +99,8 @@ namespace grapeFruitRebuild
 
             #endregion
 
+            Globals.safeDelete = true;
+
             Logger.Log(1, "Set hostname to \"livecd\""); ;
             Globals.hostname = "livecd";
             Logger.Log(1, "Init done");

--- a/Mandb.cs
+++ b/Mandb.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.VisualBasic;
+using System;
 
 namespace grapeFruitRebuild
 {
@@ -6,103 +7,106 @@ namespace grapeFruitRebuild
     {
         public static void Man(string command)
         {
+            string usage = "";
+            string description = "";
+            bool valid = true;
+
             //"""""mandb"""""
             switch (command)
             {
                 case "echo":
-                    Console.WriteLine("Usage: echo <text>");
-                    Console.WriteLine("\"Echoes\" back text after the command");
+                    usage = "echo <input>";
+                    description = "\"Echoes\" back text after the command";
                     break;
 
                 case "clear":
-                    Console.WriteLine("Usage: clear");
-                    Console.WriteLine("Clears screen");
+                    usage = "clear";
+                    description = "Clears screen";
                     break;
 
                 case "time":
-                    Console.WriteLine("Usage: time");
-                    Console.WriteLine("Displays current time based on RTC");
+                    usage = "time";
+                    description = "Displays current time based on RTC";
                     break;
 
                 case "help":
                 case "commands":
-                    Console.WriteLine("Usage: help <or> commands");
-                    Console.WriteLine("Displays the list of currently available commands");
+                    usage = "{help | commands} [<group>]";
+                    description = "Displays information text for help categories OR\ndisplays commands of category";
                     break;
 
                 case "throwex":
-                    Console.WriteLine("Usage: throwex");
-                    Console.WriteLine("Throws an exception to test current exception handling");
+                    usage = "throwex";
+                    description = "Throws an exception to test current exception handling";
                     break;
 
                 case "env":
-                    Console.WriteLine("Usage: env");
-                    Console.WriteLine("Lists the environment variables and their values");
+                    usage = "env";
+                    description = "Lists the environment variables and their values";
                     break;
 
                 case "envedit":
-                    Console.WriteLine("Usage: envedit");
-                    Console.WriteLine("Starts the environment variable editor");
+                    usage = "envedit";
+                    description = "Starts the environment variable editor";  
                     break;
 
                 case "shutdown":
-                    Console.WriteLine("Usage: shutdown");
-                    Console.WriteLine("Shuts down the system (asks for confirmation)");
+                    usage = "shutdown";
+                    description = "Shuts down the system (asks for confirmation)";
                     break;
 
                 case "reboot":
-                    Console.WriteLine("Usage: reboot");
-                    Console.WriteLine("Reboots the system (asks for confirmation)");
+                    usage = "reboot";
+                    description = "Reboots the system (asks for confirmation)";
                     break;
 
                 case "ls":
                 case "dir":
-                    Console.WriteLine("Usage: ls/dir <or> ls/dir <path>");
-                    Console.WriteLine("Lists contents of current working directory or the contents of the specified path");
+                    usage = "{ls | dir} [<path>]";
+                    description = "Lists contents of current working directory OR\nthe contents of the specified path";
                     break;
 
                 case "la":
-                    Console.WriteLine("Usage: la <or> la <path>");
-                    Console.WriteLine("Outputs a verbose listing of the current working directory or of the specified path");
+                    usage = "la [<path>]";
+                    description = "Outputs verbose list of contents of current working directory OR the contents of the specified path";
                     break;
 
                 case "cd":
-                    Console.WriteLine("Usage: cd <path>");
-                    Console.WriteLine("Changes directory to specified path");
+                    usage = "cd [<path>]";
+                    description = "Changes directory to specified path OR\nif no parameter is set, changes directory to FS root";
                     break;
 
                 case "pwd":
-                    Console.WriteLine("Usage: pwd");
-                    Console.WriteLine("Prints current working directory");
+                    usage = "pwd";
+                    description = "Prints current working directory path";
                     break;
 
                 case "touch":
-                    Console.WriteLine("Usage: touch <filename>");
-                    Console.WriteLine("Creates empty file with the specified name");
+                    usage = "touch <path>";
+                    description = "Creates a null terminated empty file at specified path";
                     break;
 
                 case "cat":
-                    Console.WriteLine("Usage: cat <filename>");
-                    Console.WriteLine("List contents of file");
+                    usage = "cat <filename>";
+                    description = "Outputs contents of file";
                     break;
 
                 case "mkdir":
                 case "md":
-                    Console.WriteLine("Usage: mkdir/md <dirname>");
-                    Console.WriteLine("Creates a directory with the specified name");
-                    Console.WriteLine("If there are \\-s included, it will create a new directory at the path");
+                    usage = "{mkdir | md} <directory name>";
+                    description = "Creates a directory with the specified name OR\nif name has \\, it will be created at the specified path";
                     break;
 
                 case "copy":
                 case "cp":
-                    Console.WriteLine("Usage: copy/cp <source> <target>");
-                    Console.WriteLine("Copies a file to the specified target");
+                    usage = "{copy | cp} <source> <target>";
+                    description = "Copies source file to target path";
                     break;
 
                 case "move":
                 case "mv":
-                    Console.WriteLine("Usage: move/mv <source> <target>");
-                    Console.WriteLine("Moves a file to the specified target");
+                    usage = "{move | mv} <source> <target>";
+                    description = "Moves source file to target path";
                     break;
 
                 //case "gfdisk":
@@ -128,8 +132,8 @@ namespace grapeFruitRebuild
                 //    break;
 
                 case "whatis":
-                    Console.WriteLine("Usage: whatis <command>");
-                    Console.WriteLine("Information about command specified");
+                    usage = "whatis <command>";
+                    description = "Outputs information about specified command";
                     break;
 
                 //case "kblayout":
@@ -143,17 +147,13 @@ namespace grapeFruitRebuild
                 //    break;
 
                 case "nano":
-                    Console.WriteLine("Usage: nano // nano <file path>");
-                    Console.WriteLine("GrapeFruitNano file editor (similar to nano on *nix systems)");
+                    usage = "nano [<filepath>]";
+                    description = "Open GrapeFruitNano text editor with or without a file open";
                     break;
 
                 case "rm":
-                    Console.WriteLine("Usage: rm <path>");
-                    Console.WriteLine("Removes file at path");
-                    Console.WriteLine("Can take arguments -r and -d");
-                    Console.WriteLine("- rm <path>: removes regular file at path");
-                    Console.WriteLine("- rm -d <path>: removes empty directory at path");
-                    Console.WriteLine("- rm -r <path>: removes directory recursively at path");
+                    usage = "rm <path> [-r | -d]";
+                    description = "Remove file OR directory at specified path\n-r: delete directory recursively\n-d: delete directory if it's empty";
                     break;
 
                 //case "desktop":
@@ -167,9 +167,14 @@ namespace grapeFruitRebuild
                 //    break;
 
                 default:
-                    Console.WriteLine("Nothing appropriate");
+                    valid = false;
                     break;
             }
+
+            if (valid)
+                Console.WriteLine("Usage: " + usage + "\n" + description);
+            else
+                Console.WriteLine("Nothing appropriate");
         }
     }
 }

--- a/Mandb.cs
+++ b/Mandb.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualBasic;
-using System;
+﻿using System;
 
 namespace grapeFruitRebuild
 {

--- a/Mandb.cs
+++ b/Mandb.cs
@@ -138,8 +138,12 @@ namespace grapeFruitRebuild
                     break;
 
                 case "rm":
-                    Console.WriteLine("Usage: rm <file path>");
-                    Console.WriteLine("Removes file");
+                    Console.WriteLine("Usage: rm <path>");
+                    Console.WriteLine("Removes file at path");
+                    Console.WriteLine("Can take arguments -r and -d");
+                    Console.WriteLine("- rm <path>: removes regular file at path");
+                    Console.WriteLine("- rm -d <path>: removes empty directory at path");
+                    Console.WriteLine("- rm -r <path>: removes directory recursively at path");
                     break;
 
                 //case "desktop":

--- a/Mandb.cs
+++ b/Mandb.cs
@@ -35,6 +35,16 @@ namespace grapeFruitRebuild
                     Console.WriteLine("Throws an exception to test current exception handling");
                     break;
 
+                case "env":
+                    Console.WriteLine("Usage: env");
+                    Console.WriteLine("Lists the environment variables and their values");
+                    break;
+
+                case "envedit":
+                    Console.WriteLine("Usage: envedit");
+                    Console.WriteLine("Starts the environment variable editor");
+                    break;
+
                 case "shutdown":
                     Console.WriteLine("Usage: shutdown");
                     Console.WriteLine("Shuts down the system (asks for confirmation)");

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,9 @@
 - Networking tweaks
 
 ### Low priority, future plans
+- Possible large shell rework
+	- Up and down arrow to browse command buffer
+	- `^C` interrupt
 - Login system (store usernames and passwords on disk)
 - Proper installer for the system
 - Custom EFI bootloader

--- a/TODO.md
+++ b/TODO.md
@@ -10,3 +10,4 @@
 - Login system (store usernames and passwords on disk)
 - Proper installer for the system
 - Custom EFI bootloader
+- Make a custom `choice` function that can have either Y or N as the default action on Enter key

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,9 @@
 ﻿# TO-DO List // Roadmap
 
 ### High priority
-- Support for *REAL* FAT32 (hard drives) and ISO9660 (optical discs)
 - Use *""* in file paths ✅
-- Copy, move, delete commands (`cp`, `mv`, `rm`, including `rm -r`)
-	- `cp˙`, `mv` and `rm` works, but `rm` cannot do recursive delete ✅
+- Copy, move, delete commands (`cp`, `mv`, `rm`, `rm -r`, `rm -d`) ✅ 
+- Support for *REAL* FAT32 (hard drives) and ISO9660 (optical discs)
 - Networking tweaks
 
 ### Low priority, future plans

--- a/debugmenu.cs
+++ b/debugmenu.cs
@@ -1,0 +1,98 @@
+﻿using System;
+
+using Cosmos.System.FileSystem;
+using System.IO;
+using Cosmos.HAL;
+using Cosmos.Core;
+using Cosmos.System.FileSystem.FAT;
+using Cosmos.System.FileSystem.ISO9660;
+using System.Collections.Generic;
+
+#pragma warning disable CA2211
+#pragma warning disable IDE0059
+
+namespace grapeFruitRebuild
+{
+    public class debugmenu
+    {
+        static string input = "";
+        public static void main()
+        {
+            Console.WriteLine("- - - Debug Menu - - -\n");
+            Console.WriteLine("Available commands: env, sysinfo, vdevs, log, exit");
+            do
+            {
+                Console.Write("> ");
+                input = Console.ReadLine();
+                switch (input)
+                {
+                    case "env":
+                        env();
+                        break;
+                    case "sysinfo":
+                        Globals.Printsysteminfo();
+                        break;
+                    case "vdevs":
+                        vdevs();
+                        break;
+                    case "log":
+                        log();
+                        break;
+                    case "help":
+                    case "?":
+                        Console.WriteLine("Available commands: env, sysinfo, vdevs, log, exit");
+                        break;
+                    case "exit":
+                        break;
+                    default:
+                        Console.WriteLine("Unknown command");
+                        break;
+                }
+            } while (input != "exit");
+        }
+
+        private static void env()
+        {
+            Console.WriteLine("devbuild: " + Globals.devBuild);
+            Console.WriteLine("currentuser: " + Globals.currentuser);
+            Console.WriteLine("hostname: " + Globals.hostname);
+            Console.WriteLine("workingdir: " + Globals.workingdir);
+            Console.WriteLine("oldpwd: " + Globals.oldpwd);
+            Console.WriteLine("swapYZ: " + Globals.swapYZ);
+            Console.WriteLine("safeDelete: " + Globals.safeDelete);
+        }
+        private static void vdevs()
+        {
+            Console.WriteLine("\nVirtual devices\n");
+
+            Console.WriteLine("CosmosVFS disks:");
+            List<Disk> vfsDisks = Globals.vFS.GetDisks();
+            foreach (Disk disk in vfsDisks) {
+                disk.DisplayInformation();
+                Console.Write("\nContinue . . .");
+                Console.ReadKey();
+                Console.Write('\n');
+            }
+
+            Console.WriteLine("NIC info");
+            Console.WriteLine("Name: " + Globals.nic.Name);
+            Console.WriteLine("Name ID: " + Globals.nic.NameID);
+            Console.WriteLine("MAC: " + Globals.nic.MACAddress);
+            Console.WriteLine("Card Type: " + Globals.nic.CardType);
+
+            Console.Write("\nContinue . . .");
+            Console.ReadKey();
+            Console.Write('\n');
+        }
+        private static void log()
+        {
+            byte type = 0;
+            Console.Write("\nType (int): ");
+            type = Convert.ToByte(Console.ReadLine());
+            string msg = "";
+            Console.Write("msg? (str): ");
+            msg = Console.ReadLine();
+            Logger.Log(type, msg);
+        }
+    }
+}

--- a/grapeFruitRebuild.csproj
+++ b/grapeFruitRebuild.csproj
@@ -13,13 +13,15 @@
         <StartCosmosGDB>False</StartCosmosGDB>
         <VisualStudioDebugPort>Pipe: Cosmos\Serial</VisualStudioDebugPort>
         <CosmosDebugPort>Serial: COM1</CosmosDebugPort>
-        <Launch>ISO</Launch>
+        <Launch>VMware</Launch>
         <Profile>VMware</Profile>
         <Description>Use VMware Player or Workstation to deploy and debug.</Description>
         <PxeInterface>192.168.0.8</PxeInterface>
-        <RemoveBootDebugOutput>True</RemoveBootDebugOutput>
-        <UseUEFI>False</UseUEFI>
-        <DebugEnabled>False</DebugEnabled>
+        <RemoveBootDebugOutput>False</RemoveBootDebugOutput>
+        <UseUEFI>True</UseUEFI>
+        <DebugEnabled>True</DebugEnabled>
+        <Timeout>1</Timeout>
+        <VMWareEdition>Player</VMWareEdition>
     </PropertyGroup>
 
     <ItemGroup>

--- a/grapeFruitRebuild.csproj
+++ b/grapeFruitRebuild.csproj
@@ -20,7 +20,7 @@
         <RemoveBootDebugOutput>False</RemoveBootDebugOutput>
         <UseUEFI>True</UseUEFI>
         <DebugEnabled>True</DebugEnabled>
-        <Timeout>1</Timeout>
+        <Timeout></Timeout>
         <VMWareEdition>Player</VMWareEdition>
     </PropertyGroup>
 

--- a/grapeFruitRebuild.csproj
+++ b/grapeFruitRebuild.csproj
@@ -13,11 +13,11 @@
         <StartCosmosGDB>False</StartCosmosGDB>
         <VisualStudioDebugPort>Pipe: Cosmos\Serial</VisualStudioDebugPort>
         <CosmosDebugPort>Serial: COM1</CosmosDebugPort>
-        <Launch>ISO</Launch>
+        <Launch>VMware</Launch>
         <Profile>VMware</Profile>
         <Description>Use VMware Player or Workstation to deploy and debug.</Description>
         <PxeInterface>192.168.0.8</PxeInterface>
-        <RemoveBootDebugOutput>True</RemoveBootDebugOutput>
+        <RemoveBootDebugOutput>False</RemoveBootDebugOutput>
         <UseUEFI>False</UseUEFI>
         <DebugEnabled>True</DebugEnabled>
         <Timeout></Timeout>

--- a/grapeFruitRebuild.csproj
+++ b/grapeFruitRebuild.csproj
@@ -13,12 +13,12 @@
         <StartCosmosGDB>False</StartCosmosGDB>
         <VisualStudioDebugPort>Pipe: Cosmos\Serial</VisualStudioDebugPort>
         <CosmosDebugPort>Serial: COM1</CosmosDebugPort>
-        <Launch>VMware</Launch>
+        <Launch>ISO</Launch>
         <Profile>VMware</Profile>
         <Description>Use VMware Player or Workstation to deploy and debug.</Description>
         <PxeInterface>192.168.0.8</PxeInterface>
-        <RemoveBootDebugOutput>False</RemoveBootDebugOutput>
-        <UseUEFI>True</UseUEFI>
+        <RemoveBootDebugOutput>True</RemoveBootDebugOutput>
+        <UseUEFI>False</UseUEFI>
         <DebugEnabled>True</DebugEnabled>
         <Timeout></Timeout>
         <VMWareEdition>Player</VMWareEdition>


### PR DESCRIPTION
# 0.16.1
- Commands to access environment variables
- "Safe delete" function when using `rm`
    - Can be changed using `envedit`
- Changed error screen to just a simple message
    - Full kernel stops are handled by internal Cosmos components, "surface level" exceptions are handled by the error message system
- New version of Cosmos allows compilation for UEFI targets
- `rm` can now delete directories recursively (`-r`) or remove empty ones (`-d`)
- `cd` can now go back to "oldpwd" using `cd -` or `cd $OLDPWD` (both options are hard-coded)
- basics of "debugmenu" added, more functionality later